### PR TITLE
Added EBS optimized EC2 instance type data.

### DIFF
--- a/aws.json
+++ b/aws.json
@@ -468,6 +468,7 @@
 		    "ramMB" : 1700,
 		    "storageGB" : [10, 160],
 		    "i/o" : "moderate",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [32,64]},
 		"m1.medium" : {
 		    "compute_units" : 2,
@@ -475,6 +476,7 @@
 		    "ramMB" : 3750,
 		    "storageGB" : [10, 410],
 		    "i/o" : "moderate",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [32,64]},
 		"m1.large" : {
 		    "compute_units" : 4,
@@ -482,6 +484,7 @@
 		    "ramMB" : 7500,
 		    "storageGB" : [10, 420, 420],
 		    "i/o" : "high",
+		    "ebs_optimized_iopsMbps" : 500,
 		    "arch" : [64]},
 		"m1.xlarge" : {
 		    "compute_units" : 8,
@@ -489,6 +492,7 @@
 		    "ramMB" : 15000,
 		    "storageGB" : [10, 420, 420, 420, 420],
 		    "i/o" : "high",
+		    "ebs_optimized_iopsMbps" : 1000,
 		    "arch" : [64]},
 		"t1.micro" : {
 		    "compute_units" : 2,
@@ -496,6 +500,7 @@
 		    "ramMB" : 613,
 		    "storage" : [],
 		    "i/o" : "low",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [32,64]},
 		"c1.medium" : {
 		    "compute_units" : 5,
@@ -503,6 +508,7 @@
 		    "ramMB" : 1700,
 		    "storageGB" : [10, 350],
 		    "i/o" : "moderate",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [32,64]},
 		"c1.xlarge" : {
 		    "compute_units" : 20,
@@ -510,6 +516,7 @@
 		    "ramMB" : 7000,
 		    "storageGB" : [10, 420, 420, 420, 420],
 		    "i/o" : "high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"m2.xlarge" : {
 		    "compute_units" : 6.5,
@@ -517,6 +524,7 @@
 		    "ramMB" : 17100,
 		    "storageGB" : [10, 420],
 		    "i/o" : "moderate",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"m2.2xlarge" : {
 		    "compute_units" : 13,
@@ -524,6 +532,7 @@
 		    "ramMB" : 34200,
 		    "storageGB" : [10, 840],
 		    "i/o" : "high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"m2.4xlarge" : {
 		    "compute_units" : 26,
@@ -531,6 +540,7 @@
 		    "ramMB" : 68400,
 		    "storageGB" : [10, 840, 840],
 		    "i/o" : "high",
+		    "ebs_optimized_iopsMbps" : 1000,
 		    "arch" : [64]},
 		"cc1.4xlarge" : {
 		    "compute_units" : 33.5,
@@ -538,6 +548,7 @@
 		    "ramMB" : 23000,
 		    "storageGB" : [10, 840, 840],
 		    "i/o" : "very high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"cc2.8xlarge" : {
 		    "compute_units" : 88,
@@ -545,6 +556,7 @@
 		    "ramMB" : 60500,
 		    "storageGB" : [10, 840, 840, 840, 840],
 		    "i/o" : "very high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"cg1.4xlarge" : {
 		    "compute_units" : 33.5,
@@ -552,6 +564,7 @@
 		    "ramMB" : 22000,
 		    "storageGB" : [10, 840, 840],
 		    "i/o" : "very high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]},
 		"hi1.4xlarge" : {
 		    "compute_units" : 35,
@@ -559,6 +572,7 @@
 		    "ramMB" : 60500,
 		    "storageGB" : [10, 1024, 1024],
 		    "i/o" : "very high",
+		    "ebs_optimized_iopsMbps" : 0,
 		    "arch" : [64]}
 	    },
 	    "path": "/",


### PR DESCRIPTION
This is less straight forward than usual, here is how I judged things:
- I've named the field _ebs_optimized_iopsMbps_
  - this mirrors how you approached e.g. _storageGB_
  - the naming reflects AWS terminology from the EC2 instance point of view, i.e. doesn't mention the EBS volume point of view, where 'Provisioned IOPS' would have been more appropriate
- I've added that field to every instance type
  - this mirrors how you approached e.g. _gpus_
  - it might be a bit misleading for some types still:  
    _"Cluster Compute, Cluster GPU and High I/O instances do not currently support EBS Optimization, but provide customers with high bandwidth networking and can also be used with EBS Provisioned IOPS volumes for improved consistency and performance."_

This is sufficient for me right now like so, suggestions/improvements welcome of course.
