### PR TITLE
Added Elastic Beanstalk region ap-southeast-1.

### DIFF
--- a/aws.json
+++ b/aws.json
@@ -295,9 +295,15 @@
 		},
 		{
 		    "endpoint": "elasticbeanstalk.ap-northeast-1.amazonaws.com",
-		    "name": "us-east-1",
+		    "name": "ap-northeast-1",
 		    "protocols": ["HTTPS"],
 		    "description": "Asia Pacific (Tokyo)"
+		},
+		{
+		    "endpoint": "elasticbeanstalk.ap-southeast-1.amazonaws.com",
+		    "name": "ap-southeast-1",
+		    "protocols": ["HTTPS"],
+		    "description": "Asia Pacific (Singapore)"
 		},
 		{
 		    "endpoint": "elasticbeanstalk.eu-west-1.amazonaws.com",


### PR DESCRIPTION
Please note that this implies a fix for commit 8248bc4, where endpoint _elasticbeanstalk.ap-northeast-1.amazonaws.com_ has been added with name _us-west-1_ (see [line 260](https://github.com/garnaat/missingcloud/commit/8248bc4b05b07b8ce2f4e25a6f051ed2040d975b#L0R260)).
