### PR TITLE
Added EC2 instance type number of cores.

### DIFF
--- a/aws.json
+++ b/aws.json
@@ -464,6 +464,7 @@
 	    "instance_types" : {
 		"m1.small" : {
 		    "compute_units" : 1,
+		    "cores" : 1,
 		    "gpus" : 0,
 		    "ramMB" : 1700,
 		    "storageGB" : [10, 160],
@@ -472,6 +473,7 @@
 		    "arch" : [32,64]},
 		"m1.medium" : {
 		    "compute_units" : 2,
+		    "cores" : 1,
 		    "gpus" : 0,
 		    "ramMB" : 3750,
 		    "storageGB" : [10, 410],
@@ -480,6 +482,7 @@
 		    "arch" : [32,64]},
 		"m1.large" : {
 		    "compute_units" : 4,
+		    "cores" : 2,
 		    "gpus" : 0,
 		    "ramMB" : 7500,
 		    "storageGB" : [10, 420, 420],
@@ -488,6 +491,7 @@
 		    "arch" : [64]},
 		"m1.xlarge" : {
 		    "compute_units" : 8,
+		    "cores" : 4,
 		    "gpus" : 0,
 		    "ramMB" : 15000,
 		    "storageGB" : [10, 420, 420, 420, 420],
@@ -496,6 +500,7 @@
 		    "arch" : [64]},
 		"t1.micro" : {
 		    "compute_units" : 2,
+		    "cores" : 1,
 		    "gpus" : 0,
 		    "ramMB" : 613,
 		    "storage" : [],
@@ -504,6 +509,7 @@
 		    "arch" : [32,64]},
 		"c1.medium" : {
 		    "compute_units" : 5,
+		    "cores" : 2,
 		    "gpus" : 0,
 		    "ramMB" : 1700,
 		    "storageGB" : [10, 350],
@@ -512,6 +518,7 @@
 		    "arch" : [32,64]},
 		"c1.xlarge" : {
 		    "compute_units" : 20,
+		    "cores" : 8,
 		    "gpus" : 0,
 		    "ramMB" : 7000,
 		    "storageGB" : [10, 420, 420, 420, 420],
@@ -520,6 +527,7 @@
 		    "arch" : [64]},
 		"m2.xlarge" : {
 		    "compute_units" : 6.5,
+		    "cores" : 2,
 		    "gpus" : 0,
 		    "ramMB" : 17100,
 		    "storageGB" : [10, 420],
@@ -528,6 +536,7 @@
 		    "arch" : [64]},
 		"m2.2xlarge" : {
 		    "compute_units" : 13,
+		    "cores" : 4,
 		    "gpus" : 0,
 		    "ramMB" : 34200,
 		    "storageGB" : [10, 840],
@@ -536,6 +545,7 @@
 		    "arch" : [64]},
 		"m2.4xlarge" : {
 		    "compute_units" : 26,
+		    "cores" : 8,
 		    "gpus" : 0,
 		    "ramMB" : 68400,
 		    "storageGB" : [10, 840, 840],
@@ -544,6 +554,7 @@
 		    "arch" : [64]},
 		"cc1.4xlarge" : {
 		    "compute_units" : 33.5,
+		    "cores" : 8,
 		    "gpus" : 0,
 		    "ramMB" : 23000,
 		    "storageGB" : [10, 840, 840],
@@ -552,6 +563,7 @@
 		    "arch" : [64]},
 		"cc2.8xlarge" : {
 		    "compute_units" : 88,
+		    "cores" : 16,
 		    "gpus" : 0,
 		    "ramMB" : 60500,
 		    "storageGB" : [10, 840, 840, 840, 840],
@@ -560,6 +572,7 @@
 		    "arch" : [64]},
 		"cg1.4xlarge" : {
 		    "compute_units" : 33.5,
+		    "cores" : 8,
 		    "gpus" : 2,
 		    "ramMB" : 22000,
 		    "storageGB" : [10, 840, 840],
@@ -568,6 +581,7 @@
 		    "arch" : [64]},
 		"hi1.4xlarge" : {
 		    "compute_units" : 35,
+		    "cores" : 16,
 		    "gpus" : 0,
 		    "ramMB" : 60500,
 		    "storageGB" : [10, 1024, 1024],


### PR DESCRIPTION
Again a not entirely straight forward one:
- there are both instance types with physical and with virtual cores
- the _hi1.4xlarge_ instance type seems to be the only one with hyper threading enabled

While one could try to cover all all variations with up to three fields eventually (e.g. _cpus_, _cores_, _hyper_treading_), I've subsumed them within a single field _cores_ instead, assuming this being a reasonable common denominator, both from a software development as well as a generic virtualized environment point of view.

This is sufficient for me right now like so, suggestions/improvements welcome of course.
