### PR TITLE
Fixed IP ranges added 20121112.

### DIFF
--- a/aws.json
+++ b/aws.json
@@ -486,7 +486,7 @@
 		    "name": "ap-southeast-2",
 		    "protocols": ["HTTPS", "HTTP"],
 		    "description": "Asia Pacific (Sydney)",
-		    "ip_ranges": ["55.252.0.0/16"]
+		    "ip_ranges": ["54.252.0.0/16"]
 		},
 		{
 		    "endpoint": "ec2.ap-northeast-1.amazonaws.com",


### PR DESCRIPTION
This fixes an apparent typo in the new ap-southeast-2 region EC2 IP ranges added in commit eae44fd4, as documented in [Amazon EC2 Public IP Ranges (20121112) ](https://forums.aws.amazon.com/ann.jspa?annID=1701) (I've launched an instance to confirm the announced ones being correct).
