### PR TITLE
Fixed Simple Workflow JSON element name.

### DIFF
--- a/aws.json
+++ b/aws.json
@@ -1382,7 +1382,7 @@
 	    "path": "/",
 	    "port": 443
 	},
-	"Simple Worflow" : {
+	"Simple Workflow" : {
 	    "name": "swf",
 	    "api_name": "swf",
 	    "description": "",


### PR DESCRIPTION
:information_source:  - Beware that this might break client code using that JSON element name as a selector, which is why I've separated this seemingly trivial fix into a separate commit for visibility.
